### PR TITLE
Test dtypes, fix constructors caching.

### DIFF
--- a/sparse/mlir_backend/_constructors.py
+++ b/sparse/mlir_backend/_constructors.py
@@ -267,11 +267,11 @@ def asarray(obj) -> Tensor:
         raise Exception(f"{type(obj)} not supported.")
 
     # TODO: support proper caching
-    if hash(obj.shape) in format_class.modules:
-        module, tensor_type = format_class.modules[hash(obj.shape)]
+    if hash((obj.shape, obj.dtype)) in format_class.modules:
+        module, tensor_type = format_class.modules[hash((obj.shape, obj.dtype))]
     else:
         module, tensor_type = format_class.get_module(obj.shape, values_dtype, index_dtype)
-        format_class.modules[hash(obj.shape)] = module, tensor_type
+        format_class.modules[hash((obj.shape, obj.dtype))] = module, tensor_type
 
     assembled_obj = format_class.assemble(module, obj)
     return Tensor(assembled_obj, module, tensor_type, format_class.disassemble, values_dtype, index_dtype)

--- a/sparse/mlir_backend/tests/test_simple.py
+++ b/sparse/mlir_backend/tests/test_simple.py
@@ -13,8 +13,8 @@ if sparse._BACKEND != sparse._BackendType.MLIR:
 parametrize_dtypes = pytest.mark.parametrize(
     "dtype",
     [
-        np.int8,
-        np.uint16,
+        np.int64,
+        np.uint64,
         np.float32,
         np.float64,
     ],
@@ -30,14 +30,14 @@ def generate_sampler(dtype: np.dtype, rng: np.random.Generator) -> typing.Callab
 
         return sampler_signed
 
-    if np.isdtype(dtype, kind="unsigned integer"):  #
+    if np.isdtype(dtype, kind="unsigned integer"):
 
         def sampler_unsigned(size: tuple[int, ...]):
             return rng.integers(0, 10, dtype=dtype, endpoint=True, size=size)
 
         return sampler_unsigned
 
-    if np.isdtype(dtype, kind="real floating"):  #
+    if np.isdtype(dtype, kind="real floating"):
 
         def sampler_real_floating(size: tuple[int, ...]):
             return -10 + 20 * rng.random(dtype=dtype, size=size)
@@ -70,8 +70,8 @@ def test_constructors(rng, dtype):
     SHAPE = (10, 5)
     DENSITY = 0.5
     sampler = generate_sampler(dtype, rng)
-    a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=np.float64, random_state=rng, data_sampler=sampler)
-    c = np.arange(50, dtype=np.float64).reshape((10, 5))
+    a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
+    c = np.arange(50, dtype=dtype).reshape((10, 5))
 
     a_tensor = sparse.asarray(a)
     c_tensor = sparse.asarray(c)
@@ -89,9 +89,9 @@ def test_add(rng, dtype):
     DENSITY = 0.5
     sampler = generate_sampler(dtype, rng)
 
-    a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=np.float64, random_state=rng, data_sampler=sampler)
-    b = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=np.float64, random_state=rng, data_sampler=sampler)
-    c = np.arange(50, dtype=np.float64).reshape((10, 5))
+    a = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
+    b = sps.random_array(SHAPE, density=DENSITY, format="csr", dtype=dtype, random_state=rng, data_sampler=sampler)
+    c = np.arange(50, dtype=dtype).reshape((10, 5))
 
     a_tensor = sparse.asarray(a)
     b_tensor = sparse.asarray(b)


### PR DESCRIPTION
Hi @hameerabbasi,

This PR adds changes to https://github.com/pydata/sparse/pull/757, namely:
- Only `float64` dtype was tested in `test_simple.py`, now it uses all parametrized dtypes.
- Constructors caching key is now `(shape, dtype)` to work correctly with different dtypes.
- For Integer dtypes, `arith.AddIOp` expects signless inputs I think - I'm not sure how to handle it here. 
- I verified that there is no memory leak with no copy `to_scipy_sparse` implementation.
